### PR TITLE
fix multiple instances of backrest causing CrashLookBackoff, update backrest, and fix imagePullSecrets

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ sources:
 maintainers:
   - name: Roberto Bochet
     email: r@robertobochet.me
-appVersion: "1.8.1"
+appVersion: "1.9.1"
 annotations:
   artifacthub.io/license: GPL-3.0-or-later
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -62,20 +62,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Docker Image Registry Secret Names evaluating values as templates
-*/}}
-{{- define "backrest.images.pullSecrets" -}}
-{{- $pullSecrets := .Values.imagePullSecrets -}}
-{{- range .Values.imagePullSecrets -}}
-    {{- $pullSecrets = append $pullSecrets (dict "name" .) -}}
-{{- end -}}
-{{- if (not (empty $pullSecrets)) }}
-imagePullSecrets:
-{{ toYaml $pullSecrets }}
-{{- end }}
-{{- end -}}
-
-{{/*
 Storage Class
 */}}
 {{- define "backrest.persistence.storageClass" -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -7,12 +7,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    type: {{ .Values.strategy.type }}
-    {{- if eq .Values.strategy.type "RollingUpdate" }}
-    rollingUpdate:
-      maxUnavailable: {{ .Values.strategy.rollingUpdate.maxUnavailable }}
-      maxSurge: {{ .Values.strategy.rollingUpdate.maxSurge }}
-    {{- end }}
+    type: Recreate
   selector:
     matchLabels:
       {{- include "backrest.selectorLabels" . | nindent 6 }}
@@ -25,7 +20,10 @@ spec:
       labels:
         {{- include "backrest.labels" . | nindent 8 }}
     spec:
-      {{- include "backrest.images.pullSecrets" . | nindent 6 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "backrest.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -16,36 +16,13 @@
             "type": "array",
             "description": "Secret to use for pulling the image",
             "default": [],
-            "items": {}
-        },
-        "replicaCount": {
-            "type": "number",
-            "description": "number of replicas for the deployment",
-            "default": 1
-        },
-        "strategy": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "description": "strategy type",
-                    "default": "RollingUpdate"
-                },
-                "rollingUpdate": {
-                    "type": "object",
-                    "properties": {
-                        "maxSurge": {
-                            "type": "string",
-                            "description": "maxSurge",
-                            "default": "100%"
-                        },
-                        "maxUnavailable": {
-                            "type": "number",
-                            "description": "maxUnavailable",
-                            "default": 0
-                        }
-                    }
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
                 }
+              }
             }
         },
         "image": {

--- a/values.yaml
+++ b/values.yaml
@@ -12,19 +12,6 @@ fullnameOverride: ""
 ## @param imagePullSecrets Secret to use for pulling the image
 imagePullSecrets: []
 
-## @param replicaCount number of replicas for the deployment
-replicaCount: 1
-
-## @section strategy
-## @param strategy.type strategy type
-## @param strategy.rollingUpdate.maxSurge maxSurge
-## @param strategy.rollingUpdate.maxUnavailable maxUnavailable
-strategy:
-  type: "RollingUpdate"
-  rollingUpdate:
-    maxSurge: "100%"
-    maxUnavailable: 0
-
 ## @section Image
 ## @param image.registry image registry, e.g. gcr.io,docker.io
 ## @param image.repository Image to start for this pod


### PR DESCRIPTION
Removing options that can lead to this error:

FATAL	oplog is locked by another instance of backrest that is using the same data directory "/data/data", kill that instance before starting another one.

Solving that by forcing deployment strategy to be Recreate and removing multi-replica option.

Also updates backrest.

And fixes imagePullSecrets, which were not validly templated before.