### PR TITLE
Fix multiple instances of backrest causing CrashLookBackoff #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@
 
 ### strategy
 
-| Name                                    | Description    | Value           |
-| --------------------------------------- | -------------- | --------------- |
-| `strategy.type`                         | strategy type  | `RollingUpdate` |
-| `strategy.rollingUpdate.maxSurge`       | maxSurge       | `100%`          |
-| `strategy.rollingUpdate.maxUnavailable` | maxUnavailable | `0`             |
+| Name                                    | Description    | Value      |
+| --------------------------------------- | -------------- | ---------- |
+| `strategy.type`                         | strategy type  | `Recreate` |
+| `strategy.rollingUpdate.maxSurge`       | maxSurge       | `100%`     |
+| `strategy.rollingUpdate.maxUnavailable` | maxUnavailable | `0`        |
 
 ### Image
 

--- a/values.schema.json
+++ b/values.schema.json
@@ -29,7 +29,7 @@
                 "type": {
                     "type": "string",
                     "description": "strategy type",
-                    "default": "RollingUpdate"
+                    "default": "Recreate"
                 },
                 "rollingUpdate": {
                     "type": "object",

--- a/values.yaml
+++ b/values.yaml
@@ -20,7 +20,7 @@ replicaCount: 1
 ## @param strategy.rollingUpdate.maxSurge maxSurge
 ## @param strategy.rollingUpdate.maxUnavailable maxUnavailable
 strategy:
-  type: "RollingUpdate"
+  type: "Recreate"
   rollingUpdate:
     maxSurge: "100%"
     maxUnavailable: 0


### PR DESCRIPTION
Switch update strategy to`Recreate` to provide a cheap and fast solution for #15, pending implementation of a more permanent solution (discussion is open here #13).