### PR TITLE
chore: bump backrest to version 1.13.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ sources:
 maintainers:
   - name: Roberto Bochet
     email: r@robertobochet.me
-appVersion: "1.12.0"
+appVersion: "1.13.0"
 annotations:
   artifacthub.io/license: GPL-3.0-or-later
 


### PR DESCRIPTION
This MR upgrades `backrest` from version `1.12.0` to `1.13.0` in `Chart.yaml` 


-  Tested a clean deployment of the chart with the new dependency.
- Tested an upgrade from an existing installation running the previous version (`1.12.0` -> `1.13.0`).

No breaking changes detected
