### PR TITLE
fix(probes): hardcode container port and use named targetPort to decouple from service port

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@
 | `config`                             | Backrest configuration forwarded to container as environment variables |                                                   |
 | `config.BACKREST_DATA`               | Backrest data path                                                     | `{{ .Values.persistence.mountPath }}/data`        |
 | `config.BACKREST_CONFIG`             | Backrest config path                                                   | `{{ .Values.persistence.mountPath }}/config.json` |
-| `config.BACKREST_PORT`               | Backrest webapp port                                                   | `0.0.0.0:{{ .Values.service.port}}`               |
+| `config.BACKREST_PORT`               | Backrest webapp port                                                   | `9898`               |
 | `config.XDG_CACHE_HOME`              | Backrest cache path                                                    | `{{ .Values.cache.mountPath }}`                   |
 | `env`                                | Additional environment variables to pass to containers                 | `[]`                                              |
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@
 | `config`                             | Backrest configuration forwarded to container as environment variables |                                                   |
 | `config.BACKREST_DATA`               | Backrest data path                                                     | `{{ .Values.persistence.mountPath }}/data`        |
 | `config.BACKREST_CONFIG`             | Backrest config path                                                   | `{{ .Values.persistence.mountPath }}/config.json` |
-| `config.BACKREST_PORT`               | Backrest webapp port                                                   | `9898`               |
+| `config.BACKREST_PORT`               | Backrest webapp port                                                   | `9898`                                            |
 | `config.XDG_CACHE_HOME`              | Backrest cache path                                                    | `{{ .Values.cache.mountPath }}`                   |
 | `env`                                | Additional environment variables to pass to containers                 | `[]`                                              |
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@
 | `config`                             | Backrest configuration forwarded to container as environment variables |                                                   |
 | `config.BACKREST_DATA`               | Backrest data path                                                     | `{{ .Values.persistence.mountPath }}/data`        |
 | `config.BACKREST_CONFIG`             | Backrest config path                                                   | `{{ .Values.persistence.mountPath }}/config.json` |
-| `config.BACKREST_PORT`               | Backrest webapp port                                                   | `9898`                                            |
 | `config.XDG_CACHE_HOME`              | Backrest cache path                                                    | `{{ .Values.cache.mountPath }}`                   |
 | `env`                                | Additional environment variables to pass to containers                 | `[]`                                              |
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 9898
+              containerPort: {{ .Values.config.BACKREST_PORT }}
               protocol: TCP
           env:
             - name: BACKREST_DATA
@@ -45,7 +45,7 @@ spec:
             - name: BACKREST_CONFIG
               value: {{ tpl .Values.config.BACKREST_CONFIG . }}
             - name: BACKREST_PORT
-              value: {{ tpl .Values.config.BACKREST_PORT . }}
+              value: 0.0.0.0:{{ .Values.config.BACKREST_PORT | toString }}
             - name: XDG_CACHE_HOME
               value: {{ tpl .Values.config.XDG_CACHE_HOME . }}
             {{- if gt (len .Values.env) 0 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.config.BACKREST_PORT }}
+              containerPort: 9898
               protocol: TCP
           env:
             - name: BACKREST_DATA
@@ -45,7 +45,7 @@ spec:
             - name: BACKREST_CONFIG
               value: {{ tpl .Values.config.BACKREST_CONFIG . }}
             - name: BACKREST_PORT
-              value: 0.0.0.0:{{ .Values.config.BACKREST_PORT | toString }}
+              value: 0.0.0.0:9898
             - name: XDG_CACHE_HOME
               value: {{ tpl .Values.config.XDG_CACHE_HOME . }}
             {{- if gt (len .Values.env) 0 }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -48,6 +48,6 @@ spec:
     {{- if  .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
     {{- end }}
-      targetPort: {{ .Values.service.port }}
+      targetPort: {{ .Values.config.BACKREST_PORT }}
   selector:
     {{- include "backrest.selectorLabels" . | nindent 4 }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -48,6 +48,6 @@ spec:
     {{- if  .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
     {{- end }}
-      targetPort: {{ .Values.config.BACKREST_PORT }}
+      targetPort: http
   selector:
     {{- include "backrest.selectorLabels" . | nindent 4 }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -410,9 +410,9 @@
                     "default": "{{ .Values.persistence.mountPath }}/config.json"
                 },
                 "BACKREST_PORT": {
-                    "type": "string",
+                    "type": "number",
                     "description": "Backrest webapp port",
-                    "default": "0.0.0.0:{{ .Values.service.port}}"
+                    "default": "9898"
                 },
                 "XDG_CACHE_HOME": {
                     "type": "string",

--- a/values.schema.json
+++ b/values.schema.json
@@ -412,7 +412,7 @@
                 "BACKREST_PORT": {
                     "type": "number",
                     "description": "Backrest webapp port",
-                    "default": "9898"
+                    "default": 9898
                 },
                 "XDG_CACHE_HOME": {
                     "type": "string",

--- a/values.schema.json
+++ b/values.schema.json
@@ -409,11 +409,6 @@
                     "description": "Backrest config path",
                     "default": "{{ .Values.persistence.mountPath }}/config.json"
                 },
-                "BACKREST_PORT": {
-                    "type": "number",
-                    "description": "Backrest webapp port",
-                    "default": 9898
-                },
                 "XDG_CACHE_HOME": {
                     "type": "string",
                     "description": "Backrest cache path",

--- a/values.yaml
+++ b/values.yaml
@@ -208,12 +208,10 @@ affinity: {}
 ## @extra config Backrest configuration forwarded to container as environment variables
 ## @param config.BACKREST_DATA Backrest data path
 ## @param config.BACKREST_CONFIG Backrest config path
-## @param config.BACKREST_PORT Backrest webapp port
 ## @param config.XDG_CACHE_HOME Backrest cache path
 config:
   BACKREST_DATA: "{{ .Values.persistence.mountPath }}/data"
   BACKREST_CONFIG: "{{ .Values.persistence.mountPath }}/config.json"
-  BACKREST_PORT: 9898
   XDG_CACHE_HOME: "{{ .Values.cache.mountPath }}"
 
 ## @param env  Additional environment variables to pass to containers

--- a/values.yaml
+++ b/values.yaml
@@ -213,7 +213,7 @@ affinity: {}
 config:
   BACKREST_DATA: "{{ .Values.persistence.mountPath }}/data"
   BACKREST_CONFIG: "{{ .Values.persistence.mountPath }}/config.json"
-  BACKREST_PORT: "0.0.0.0:{{ .Values.service.port}}"
+  BACKREST_PORT: 9898
   XDG_CACHE_HOME: "{{ .Values.cache.mountPath }}"
 
 ## @param env  Additional environment variables to pass to containers


### PR DESCRIPTION
Kubernetes liveness/readiness probes would fail if a custom `service.port` was configured, because probes targeted the hardcoded container port (9898) while BACKREST_PORT could be set to a different value.

This fix:
- Hardcodes `BACKREST_PORT` to `0.0.0.0:9898` — the internal container port is fixed since all traffic is routed through the Kubernetes Service anyway
- Changes `targetPort` from `{{ .Values.service.port }}` to the named port `http`, ensuring probes always reference the correct container port regardless of the service port configuration
- Removes the `config.BACKREST_PORT` option from `values.yaml`, `values.schema.json`, and documentation

Keeping the internal port fixed prevents misconfiguration and guarantees that liveness/readiness probes always point to the actual port where the application is listening.